### PR TITLE
Feat/grpc and http at same port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-health",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ crc32c = "0.6.8"
 rayon = "1.10"
 tonic-health = "0.9"
 axum = "0.6"
+tower = { version = "0.4", features = ["util"] }
 zip = "4.0.0"
 bincode = { version = "2.0.1", features = ["serde"] }
 base64 = "0.21"

--- a/src/api.rs
+++ b/src/api.rs
@@ -122,3 +122,71 @@ pub fn create_router(state: AppState) -> Router {
         )
         .with_state(state)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::{DatastoreStorage, EntityWithMetadata, KeyId, KeyStruct};
+    use crate::google::datastore::v1::Entity;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower::ServiceExt;
+
+    fn test_state() -> AppState {
+        AppState {
+            storage: Arc::new(RwLock::new(DatastoreStorage::default())),
+            operations: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    #[tokio::test]
+    async fn root_healthcheck_returns_ok() {
+        let app = create_router(test_state());
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn reset_clears_datastore_storage() {
+        let state = test_state();
+        {
+            let mut storage = state.storage.write().await;
+            storage.entities.insert(
+                KeyStruct {
+                    project_id: "test-project".to_string(),
+                    namespace: String::new(),
+                    path_elements: vec![("Task".to_string(), KeyId::StringId("one".to_string()))],
+                },
+                EntityWithMetadata {
+                    entity: Entity::default(),
+                    version: 1,
+                    create_time: prost_types::Timestamp::default(),
+                    update_time: prost_types::Timestamp::default(),
+                },
+            );
+        }
+
+        let app = create_router(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reset")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(state.storage.read().await.entities.is_empty());
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -113,8 +113,23 @@ pub async fn get_operation_status(
     }
 }
 
+pub async fn healthcheck_handler() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+pub async fn reset_handler(State(state): State<AppState>) -> impl IntoResponse {
+    {
+        let mut storage = state.storage.write().await;
+        *storage = crate::database::DatastoreStorage::default();
+    }
+    state.operations.write().await.clear();
+    StatusCode::OK
+}
+
 pub fn create_router(state: AppState) -> Router {
     Router::new()
+        .route("/", get(healthcheck_handler))
+        .route("/reset", post(reset_handler))
         .route("/v1/projects/:project_id", post(import_handler))
         .route(
             "/v1/projects/:project_id/operations/:operation_id",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
 use crate::api::create_router;
 use crate::google::datastore::v1::datastore_server::DatastoreServer;
 use crate::state::AppState;
+use axum::{
+    body::{Body, boxed},
+    http::Request,
+};
 use clap::Parser;
 use database::DatastoreStorage;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::{signal, sync::RwLock}; // Import the tokio signal module
-use tonic::transport::Server;
+use tonic::server::NamedService;
 use tracing_subscriber::EnvFilter;
 
 pub mod api;
@@ -21,21 +25,9 @@ pub mod state;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    /// The host for the gRPC server to listen on
-    #[arg(long, default_value = "127.0.0.1")]
-    grpc_host: String,
-
-    /// The port for the gRPC server to listen on
-    #[arg(long, default_value_t = 8042)]
-    grpc_port: u16,
-
-    /// The host for the HTTP server to listen on
-    #[arg(long, default_value = "127.0.0.1")]
-    http_host: String,
-
-    /// The port for the HTTP server to listen on
-    #[arg(long, default_value_t = 8043)]
-    http_port: u16,
+    /// The host:port for both Datastore gRPC and local HTTP endpoints.
+    #[arg(long, default_value = "127.0.0.1:8042")]
+    host_port: String,
 
     /// Do not store data on disk
     #[arg(long)]
@@ -91,18 +83,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cli = Cli::parse();
     let store_on_disk = !cli.no_store_on_disk;
 
-    // --- gRPC Server Setup ---
-    let grpc_addr: SocketAddr = format!("{}:{}", cli.grpc_host, cli.grpc_port)
-        .parse()
-        .unwrap_or_else(|e| {
-            tracing::error!(
-                "Invalid gRPC address format '{}:{}', error: {}. Using default 127.0.0.1:8042.",
-                cli.grpc_host,
-                cli.grpc_port,
-                e
-            );
-            SocketAddr::from(([127, 0, 0, 1], 8042))
-        });
+    let listen_addr: SocketAddr = cli.host_port.parse().unwrap_or_else(|e| {
+        tracing::error!(
+            "Invalid --host-port '{}', error: {}. Using default 127.0.0.1:8042.",
+            cli.host_port,
+            e
+        );
+        SocketAddr::from(([127, 0, 0, 1], 8042))
+    });
 
     let emulator = DatastoreEmulator::new(store_on_disk);
     let app_state = AppState {
@@ -116,41 +104,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .set_serving::<DatastoreServer<DatastoreEmulator>>()
         .await;
 
-    // --- HTTP Server Setup ---
-    let http_addr: SocketAddr = format!("{}:{}", cli.http_host, cli.http_port).parse()?;
-    let http_router = create_router(app_state.clone());
-    let http_server = axum::Server::bind(&http_addr).serve(http_router.into_make_service());
-
-    tracing::info!("Datastore emulator (gRPC) listening on {}", grpc_addr);
-    tracing::info!("HTTP server listening on {}", http_addr);
-
     let datastore_service = DatastoreServer::new(emulator)
         .max_encoding_message_size(16 * 1024 * 1024) // 16 MB
         .max_decoding_message_size(16 * 1024 * 1024); // 16 MB
-    let grpc_server = Server::builder()
-        .add_service(datastore_service)
-        .add_service(health_service)
-        .serve(grpc_addr);
+    let grpc_path = format!("/{}/*rest", DatastoreServer::<DatastoreEmulator>::NAME);
+    let datastore_service =
+        tower::ServiceExt::<Request<Body>>::map_response(datastore_service, |res| res.map(boxed));
+    let health_service =
+        tower::ServiceExt::<Request<Body>>::map_response(health_service, |res| res.map(boxed));
 
-    // --- Run both servers concurrently with graceful shutdown ---
+    let app = create_router(app_state.clone())
+        .route_service(&grpc_path, datastore_service)
+        .route_service("/grpc.health.v1.Health/*rest", health_service);
+
+    tracing::info!(
+        "Datastore emulator HTTP and gRPC listening on {}",
+        listen_addr
+    );
+
+    let server = axum::Server::bind(&listen_addr).serve(app.into_make_service());
+
+    // --- Run the server with graceful shutdown ---
     tokio::select! {
-        // Branch 1: Run the servers. This is now a single future.
         res = async {
-            tokio::try_join!(
-                async {
-                    grpc_server
-                        .await
-                        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
-                },
-                async {
-                    http_server
-                        .await
-                        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
-                }
-            )
+            server
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
         } => {
             if let Err(e) = res {
-                tracing::error!("One of the servers failed: {}", e);
+                tracing::error!("Server failed: {}", e);
             }
         },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a health check endpoint for real-time monitoring of server readiness and availability
  * Added a reset endpoint to clear and reinitialize all server state and persistent data storage

* **Chores**
  * Consolidated multiple server components into a single unified server instance for streamlined operations
  * Simplified startup configuration by replacing separate host and port arguments with a single host-port parameter

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibeira/datastore-emulator/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->