### PR TITLE
Add release publishing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
-        cache: 'poetry'
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,19 @@ name: Run Tests
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
         cache: 'poetry'
@@ -28,10 +30,12 @@ jobs:
       run: poetry install --no-interaction --no-root
 
     - name: Set up Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
+
+    - name: Build release Docker image
+      run: docker build -t datastore-emulator:ci .
 
     - name: Start emulators
       run: docker compose up --build -d

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,71 @@
+name: Homebrew Tap
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to Homebrew, e.g. v0.1.1."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: Download release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          mkdir -p source/release
+          cd source/release
+          gh release download "${TAG}" -p "SHA256SUMS"
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: tap
+
+      - name: Generate formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "::error::Homebrew publishes stable releases only: ${TAG}"
+            exit 1
+          fi
+          bash source/scripts/release/generate_homebrew_formula.sh \
+            "${VERSION}" \
+            source/release/SHA256SUMS \
+            tap/Formula/datastore-emulator.rb \
+            guibeira \
+            datastore-emulator
+
+      - name: Commit and push formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
+          cd tap
+          git add Formula/datastore-emulator.rb
+          if git diff --cached --quiet -- Formula/datastore-emulator.rb; then
+            echo "No formula changes; skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "release: datastore-emulator ${VERSION}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,129 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, e.g. 0.1.1 or 0.1.1-rc1. Do not include leading v."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate and show changes without committing or tagging."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Validate version format
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'. Expected X.Y.Z or X.Y.Z-(rc|alpha|beta|pre)N."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag does not already exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.validate.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists locally."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists on origin."
+            exit 1
+          fi
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Update Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.validate.outputs.version }}"
+          python3 - "$VERSION" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          version = sys.argv[1]
+          path = pathlib.Path("Cargo.toml")
+          text = path.read_text()
+          pattern = re.compile(r'(\[package\][^\[]*?\nversion\s*=\s*)"[^"]*"', re.DOTALL)
+          new_text, count = pattern.subn(rf'\1"{version}"', text, count=1)
+          if count != 1:
+              raise SystemExit("Failed to locate [package] version field in Cargo.toml")
+          path.write_text(new_text)
+          PY
+          git --no-pager diff -- Cargo.toml
+
+      - name: Sync Cargo.lock
+        shell: bash
+        run: cargo update -p datastore-emulator
+
+      - name: Show changes
+        if: ${{ inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Dry run enabled. Changes that would be committed:"
+          git --no-pager diff -- Cargo.toml Cargo.lock
+          echo "Tag that would be created: ${{ steps.validate.outputs.tag }}"
+
+      - name: Commit and tag release
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.validate.outputs.version }}"
+          TAG="${{ steps.validate.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          if git diff --cached --quiet; then
+            echo "::error::No changes staged. Version may already be set to ${VERSION}."
+            exit 1
+          fi
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "${TAG}"
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "## Manual Release"
+            echo ""
+            echo "- Version: \`${{ steps.validate.outputs.version }}\`"
+            echo "- Tag: \`${{ steps.validate.outputs.tag }}\`"
+            echo "- Branch: \`${GITHUB_REF_NAME}\`"
+            echo "- Dry run: \`${{ inputs.dry_run }}\`"
+            if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+              echo ""
+              echo "The \`Release\` workflow will build and publish the tag."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,297 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify tag matches Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          MANIFEST_VERSION=$(
+            awk '
+              /^\[package\]/ { in_pkg = 1; next }
+              /^\[/          { in_pkg = 0 }
+              in_pkg && /^version[[:space:]]*=/ {
+                match($0, /"[^"]*"/)
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            ' Cargo.toml
+          )
+          if [[ "$TAG_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match Cargo.toml version '$MANIFEST_VERSION'."
+            exit 1
+          fi
+
+  build-archives:
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add "${{ matrix.target }}"
+
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install protobuf
+          else
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
+          fi
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build binary
+        shell: bash
+        run: cargo build --release --locked --target "${{ matrix.target }}"
+
+      - name: Create release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.validate.outputs.version }}"
+          TARGET="${{ matrix.target }}"
+          ARCHIVE="datastore-emulator-${VERSION}-${TARGET}.tar.gz"
+          mkdir -p release
+          cp "target/${TARGET}/release/datastore-emulator" release/datastore-emulator
+          chmod +x release/datastore-emulator
+          tar -C release -czf "release/${ARCHIVE}" datastore-emulator
+          rm -f release/datastore-emulator
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ matrix.target }}
+          path: release/datastore-emulator-${{ needs.validate.outputs.version }}-${{ matrix.target }}.tar.gz
+          retention-days: 1
+
+  github-release:
+    needs:
+      - validate
+      - build-archives
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download archives
+        uses: actions/download-artifact@v8
+        with:
+          path: release
+          merge-multiple: true
+          pattern: release-*
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release
+          sha256sum -- *.tar.gz > SHA256SUMS
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ needs.validate.outputs.version }}
+          generate_release_notes: true
+          files: |
+            release/*.tar.gz
+            release/SHA256SUMS
+          draft: false
+          prerelease: ${{ needs.validate.outputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-crate:
+    needs:
+      - validate
+      - github-release
+    if: ${{ needs.validate.outputs.prerelease == 'false' }}
+    runs-on: ubuntu-24.04
+    environment: release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
+
+      - name: Dry-run publish
+        shell: bash
+        run: cargo publish --dry-run --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish crate
+        shell: bash
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-docker:
+    needs:
+      - validate
+      - github-release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: guibeira/datastore-emulator
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=semver,pattern={{major}},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.validate.outputs.prerelease == 'false' }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest Docker image
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: index.docker.io/guibeira/datastore-emulator
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  publish-homebrew:
+    needs:
+      - validate
+      - github-release
+    if: ${{ needs.validate.outputs.prerelease == 'false' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: Download release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p source/release
+          cd source/release
+          gh release download "${GITHUB_REF_NAME}" -p "SHA256SUMS"
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: tap
+
+      - name: Generate formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.validate.outputs.version }}"
+          bash source/scripts/release/generate_homebrew_formula.sh \
+            "${VERSION}" \
+            source/release/SHA256SUMS \
+            tap/Formula/datastore-emulator.rb \
+            guibeira \
+            datastore-emulator
+
+      - name: Commit and push formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tap
+          git add Formula/datastore-emulator.rb
+          if git diff --cached --quiet -- Formula/datastore-emulator.rb; then
+            echo "No formula changes; skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "release: datastore-emulator ${{ needs.validate.outputs.version }}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Datastore Emulator in Rust
 ![Crates.io Version](https://img.shields.io/crates/v/datastore-emulator)
+![Docker Pulls](https://img.shields.io/docker/pulls/guibeira/datastore-emulator)
 <p align="center">
   <img src="https://github.com/guibeira/datastore-emulator/blob/main/logo.png?raw=true" alt="Project's logo"/>
 </p>
@@ -21,41 +22,46 @@ The repository includes a comprehensive test suite that runs against both this c
 
 ## How to use
 
-### Using Cargo (recommended)
+### Using Cargo
 Make sure you have Rust and Cargo installed on your system. You can install the Rust toolchain by following the instructions at [rustup.rs](https://rustup.rs/). Then, you can install the Rust Datastore emulator using Cargo:
 
 ```bash
 cargo install datastore-emulator
 ```
 
-### Using Docker compose
-You can use the following `docker-compose.yml` file to run the Rust Datastore emulator: 
+### Using Homebrew
+
+After a stable release is published:
 
 ```bash
+brew tap guibeira/datastore-emulator https://github.com/guibeira/datastore-emulator
+brew install datastore-emulator
+```
+
+### Using Docker Compose
+You can use the following `docker-compose.yml` file to run the Rust Datastore emulator: 
+
+```yaml
 services:
   datastore-emulator:
     image: guibeira/datastore-emulator:latest
     command: [
-      "--grpc-host", "0.0.0.0",
-      "--grpc-port", "8042",
-      "--http-host","0.0.0.0",
-      "--http-port","8043",
+      "--host-port", "0.0.0.0:8042",
       "--no-store-on-disk",
     ]
     ports:
-      - "8042:8042" # gRPC port for the Rust emulator
-      - "8043:8043" # HTTP port for the Rust emulator
-
+      - "8042:8042"
 ```
+
 ### Using the pre-built Docker image
 You can run the Rust Datastore emulator using the pre-built Docker image available on Docker Hub.   
 
 ```bash
-docker run -d -p 8042:8042 -p 8043:8043 guibeira/datastore-emulator:latest \
-  --grpc-host 0.0.0.0 \
-  --grpc-port 8042 \
-  --http-host 0.0.0.0 \
-  --http-port 8043 \
+docker run -d \
+  --name datastore-emulator \
+  -p 8042:8042 \
+  guibeira/datastore-emulator:latest \
+  --host-port 0.0.0.0:8042 \
   --no-store-on-disk
 ```
 
@@ -78,6 +84,18 @@ cargo run --release
 
 See the [test](https://github.com/guibeira/datastore-emulator/blob/main/tests/README.md) instructions
 
+## Releasing
+
+1. Open GitHub Actions.
+2. Run `Manual Release`.
+3. Use a version without leading `v`, for example `0.1.1`.
+4. Run first with `dry_run=true`.
+5. If the diff is correct, run again with `dry_run=false`.
+6. The pushed tag `vX.Y.Z` triggers the release pipeline.
+
+Stable releases publish GitHub Release assets, crates.io, Homebrew and Docker Hub.
+Prereleases publish GitHub Release assets and Docker prerelease tags, but skip crates.io and Homebrew.
+
 
 ## Benchmarks
 
@@ -91,4 +109,3 @@ Here are some results with 30 clients and 10 runs each:
 
 
 If you want to run the benchmarks yourself, [here](https://github.com/guibeira/datastore-emulator/tree/main/benchmark#readme) are the instructions:
-


### PR DESCRIPTION
## Summary
- add manual version/tag workflow for releases
- add tag-driven publishing workflow for GitHub Release assets, crates.io, Docker Hub, and Homebrew
- add manual Homebrew republish workflow
- update CI to validate the release Docker image on PRs
- document Cargo, Homebrew, Docker, and maintainer release flow

## Validation
- docker run --rm -v "/Users/doggao/personal/rust/datastore-emulator:/repo" -w /repo rhysd/actionlint:latest
- docker run --rm -v "/Users/doggao/personal/rust/datastore-emulator:/mnt" -w /mnt koalaman/shellcheck:stable scripts/release/generate_homebrew_formula.sh
- generated temporary Homebrew formula and ran ruby -c
- cargo fmt -- --check in rust:1.88.0-bullseye container
- cargo publish --dry-run --locked in rust:1.88.0-bullseye container with protobuf compiler and headers
- docker build -t datastore-emulator:release-smoke .
- docker run smoke test on http://127.0.0.1:18042/