### PR TITLE
ci(benchmark): per-release benchmark dashboard published to gh-pages

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,104 @@
+name: Benchmark
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      num_clients:
+        description: "Number of concurrent clients"
+        required: false
+        default: "10"
+      num_runs:
+        description: "Runs per client"
+        required: false
+        default: "20"
+
+permissions:
+  contents: write
+  deployments: write
+
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and start emulators
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose up --build -d
+          echo "Waiting for emulators to become reachable..."
+          for port in 8042 8044; do
+            for attempt in $(seq 1 60); do
+              if curl -sf "http://localhost:${port}/" >/dev/null 2>&1 \
+                 || nc -z localhost "${port}" 2>/dev/null; then
+                echo "Port ${port} is up."
+                break
+              fi
+              if [[ "${attempt}" -eq 60 ]]; then
+                echo "::error::Emulator on port ${port} did not start in time."
+                docker compose logs
+                exit 1
+              fi
+              sleep 2
+            done
+          done
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        shell: bash
+        run: pipx install poetry
+
+      - name: Install Python dependencies
+        shell: bash
+        run: poetry install --no-interaction --no-root
+
+      - name: Run benchmark
+        shell: bash
+        env:
+          NUM_CLIENTS: ${{ github.event.inputs.num_clients || '10' }}
+          NUM_RUNS: ${{ github.event.inputs.num_runs || '20' }}
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-output
+          poetry run python benchmark/test_benchmark.py \
+            --num-clients "${NUM_CLIENTS}" \
+            --num-runs "${NUM_RUNS}" \
+            --json-out benchmark-output/results.json
+          echo "--- JSON output ---"
+          cat benchmark-output/results.json
+
+      - name: Stop emulators
+        if: always()
+        shell: bash
+        run: docker compose down -v || true
+
+      - name: Publish benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Datastore Emulator Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-output/results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,8 @@ on:
         description: "Number of concurrent clients"
         required: false
         default: "10"
+      # num_runs default (20) is intentionally below the script default (100) to keep
+      # CI runtime bounded on GitHub-hosted runners. Override via workflow_dispatch.
       num_runs:
         description: "Runs per client"
         required: false
@@ -17,7 +19,6 @@ on:
 
 permissions:
   contents: write
-  deployments: write
 
 concurrency:
   group: benchmark-${{ github.ref }}
@@ -61,8 +62,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        shell: bash
-        run: pipx install poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
       - name: Install Python dependencies
         shell: bash

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -63,7 +63,29 @@ Operation: Simple Query
     - Avg time per client: 0.9780 seconds
 ```
 
+### Emitting JSON for the continuous dashboard
 
+Pass `--json-out PATH` to write results in the `github-action-benchmark`
+`customSmallerIsBetter` format. The human-readable summary is still printed:
 
+```bash
+poetry run python benchmark/test_benchmark.py \
+  --num-clients 10 --num-runs 20 \
+  --json-out benchmark-output/results.json
+```
 
+### Continuous benchmark dashboard
+
+On every `v*` tag push, `.github/workflows/benchmark.yml` runs this script
+against both emulators (`docker compose up`) and publishes the results to
+GitHub Pages via [`benchmark-action/github-action-benchmark`][gab]. The
+dashboard lives at:
+
+<https://guibeira.github.io/datastore-emulator/dev/bench/>
+
+To smoke-test without cutting a tag, run the workflow manually from the
+**Actions** tab (`Benchmark` → **Run workflow**); the manual trigger
+accepts `num_clients` and `num_runs` overrides.
+
+[gab]: https://github.com/benchmark-action/github-action-benchmark
 

--- a/benchmark/test_benchmark.py
+++ b/benchmark/test_benchmark.py
@@ -132,7 +132,7 @@ def write_json_output(rust_results, java_results, num_clients, number_of_runs_pe
     print(f"\nWrote benchmark JSON to {out}")
 
 
-def run_benchmarks(num_clients=10, number_of_runs_per_client=100):
+def run_benchmarks(num_clients=10, number_of_runs_per_client=100, json_out=None):
     # --- Create clients ---
     rust_clients = []
     for _ in range(num_clients):
@@ -214,6 +214,15 @@ def run_benchmarks(num_clients=10, number_of_runs_per_client=100):
         else:
             print(f"  - Verdict: Java was {total_rust_time/total_java_time:.2f}x faster overall.")
 
+    if json_out:
+        write_json_output(
+            rust_results,
+            java_results,
+            num_clients,
+            number_of_runs_per_client,
+            json_out,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run datastore benchmarks.")
@@ -229,6 +238,16 @@ if __name__ == "__main__":
         default=100,
         help="Number of test runs per client (default: 100).",
     )
+    parser.add_argument(
+        "--json-out",
+        type=str,
+        default=None,
+        help="Optional path to write benchmark results as github-action-benchmark customSmallerIsBetter JSON.",
+    )
     args = parser.parse_args()
 
-    run_benchmarks(num_clients=args.num_clients, number_of_runs_per_client=args.num_runs)
+    run_benchmarks(
+        num_clients=args.num_clients,
+        number_of_runs_per_client=args.num_runs,
+        json_out=args.json_out,
+    )

--- a/benchmark/test_benchmark.py
+++ b/benchmark/test_benchmark.py
@@ -1,8 +1,10 @@
 import argparse
+import json
 import statistics
 import threading
 import timeit
 import uuid
+from pathlib import Path
 
 from google.cloud import datastore
 from google.cloud.datastore.query import PropertyFilter
@@ -85,6 +87,49 @@ def run_single_client_benchmark(name, client, number_of_runs, results_list):
 
     print(f"--- Finished benchmark for one {name} client ---")
     results_list.append(client_results)
+
+
+def write_json_output(rust_results, java_results, num_clients, number_of_runs_per_client, output_path):
+    """Writes benchmark results in github-action-benchmark customSmallerIsBetter format."""
+    if not rust_results or not java_results:
+        print(
+            f"Skipping JSON output: missing rust ({len(rust_results)}) "
+            f"or java ({len(java_results)}) results."
+        )
+        return
+
+    test_names = list(rust_results[0].keys())
+    entries = []
+    for test_name in test_names:
+        rust_times = [r[test_name] for r in rust_results]
+        java_times = [j[test_name] for j in java_results]
+
+        rust_avg = statistics.mean(rust_times)
+        java_avg = statistics.mean(java_times)
+
+        entries.append({
+            "name": f"{test_name} (Rust) - avg seconds per client",
+            "unit": "s",
+            "value": round(rust_avg, 6),
+            "extra": (
+                f"{num_clients} clients, {number_of_runs_per_client} runs/client, "
+                f"total {sum(rust_times):.4f}s"
+            ),
+        })
+        entries.append({
+            "name": f"{test_name} (Java) - avg seconds per client",
+            "unit": "s",
+            "value": round(java_avg, 6),
+            "extra": (
+                f"{num_clients} clients, {number_of_runs_per_client} runs/client, "
+                f"total {sum(java_times):.4f}s"
+            ),
+        })
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(entries, indent=2))
+    print(f"\nWrote benchmark JSON to {out}")
 
 
 def run_benchmarks(num_clients=10, number_of_runs_per_client=100):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths =
     tests
+pythonpath =
+    .

--- a/tests/test_benchmark_json_output.py
+++ b/tests/test_benchmark_json_output.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmark.test_benchmark import write_json_output
+
+
+def _sample_results():
+    rust = [
+        {"Single Insert": 1.0, "Bulk Insert (50)": 2.0, "Simple Query": 0.5},
+        {"Single Insert": 1.2, "Bulk Insert (50)": 2.4, "Simple Query": 0.6},
+    ]
+    java = [
+        {"Single Insert": 5.0, "Bulk Insert (50)": 10.0, "Simple Query": 2.0},
+        {"Single Insert": 5.2, "Bulk Insert (50)": 10.4, "Simple Query": 2.2},
+    ]
+    return rust, java
+
+
+def test_emits_one_entry_per_op_per_implementation(tmp_path):
+    rust, java = _sample_results()
+    out = tmp_path / "bench.json"
+
+    write_json_output(rust, java, num_clients=2, number_of_runs_per_client=10, output_path=out)
+
+    data = json.loads(out.read_text())
+    names = [entry["name"] for entry in data]
+    assert len(data) == 6
+    assert any("Single Insert (Rust)" in n for n in names)
+    assert any("Single Insert (Java)" in n for n in names)
+    assert any("Bulk Insert (50) (Rust)" in n for n in names)
+    assert any("Bulk Insert (50) (Java)" in n for n in names)
+    assert any("Simple Query (Rust)" in n for n in names)
+    assert any("Simple Query (Java)" in n for n in names)
+
+
+def test_values_are_mean_seconds_per_client(tmp_path):
+    rust, java = _sample_results()
+    out = tmp_path / "bench.json"
+
+    write_json_output(rust, java, num_clients=2, number_of_runs_per_client=10, output_path=out)
+
+    data = {entry["name"]: entry for entry in json.loads(out.read_text())}
+    rust_entry = next(v for k, v in data.items() if k.startswith("Single Insert (Rust)"))
+    java_entry = next(v for k, v in data.items() if k.startswith("Single Insert (Java)"))
+
+    assert rust_entry["unit"] == "s"
+    assert rust_entry["value"] == pytest.approx((1.0 + 1.2) / 2, rel=1e-6)
+    assert java_entry["value"] == pytest.approx((5.0 + 5.2) / 2, rel=1e-6)
+    assert "2 clients" in rust_entry["extra"]
+    assert "10 runs/client" in rust_entry["extra"]
+
+
+def test_creates_parent_directory(tmp_path):
+    rust, java = _sample_results()
+    out = tmp_path / "nested" / "dir" / "bench.json"
+
+    write_json_output(rust, java, num_clients=2, number_of_runs_per_client=10, output_path=out)
+
+    assert out.exists()
+    assert json.loads(out.read_text())
+
+
+def test_skips_when_either_side_missing(tmp_path, capsys):
+    out = tmp_path / "bench.json"
+
+    write_json_output([], [{"Single Insert": 1.0}], num_clients=1, number_of_runs_per_client=1, output_path=out)
+
+    assert not out.exists()
+    captured = capsys.readouterr()
+    assert "Skipping" in captured.out

--- a/tests/test_benchmark_json_output.py
+++ b/tests/test_benchmark_json_output.py
@@ -59,7 +59,7 @@ def test_creates_parent_directory(tmp_path):
     write_json_output(rust, java, num_clients=2, number_of_runs_per_client=10, output_path=out)
 
     assert out.exists()
-    assert json.loads(out.read_text())
+    assert len(json.loads(out.read_text())) == 6
 
 
 def test_skips_when_either_side_missing(tmp_path, capsys):
@@ -67,6 +67,11 @@ def test_skips_when_either_side_missing(tmp_path, capsys):
 
     write_json_output([], [{"Single Insert": 1.0}], num_clients=1, number_of_runs_per_client=1, output_path=out)
 
+    assert not out.exists()
+    captured = capsys.readouterr()
+    assert "Skipping" in captured.out
+
+    write_json_output([{"Single Insert": 1.0}], [], num_clients=1, number_of_runs_per_client=1, output_path=out)
     assert not out.exists()
     captured = capsys.readouterr()
     assert "Skipping" in captured.out


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` triggered on `v*` tag pushes (plus manual `workflow_dispatch`) that spins up both emulators via `docker compose`, runs `benchmark/test_benchmark.py`, and publishes results to GitHub Pages via [`benchmark-action/github-action-benchmark`](https://github.com/benchmark-action/github-action-benchmark).
- Adds an optional `--json-out PATH` flag to `benchmark/test_benchmark.py` that emits results in the `customSmallerIsBetter` format alongside the existing human-readable summary. Existing local usage is unchanged.
- New helper `write_json_output` is covered by 4 unit tests in `tests/test_benchmark_json_output.py`. `pytest.ini` gains `pythonpath = .` so the `benchmark.test_benchmark` import resolves under pytest.
- Updates `benchmark/README.md` documenting the new flag, the workflow, and the dashboard URL (`https://guibeira.github.io/datastore-emulator/dev/bench/`).

Implementation follows the plan at `docs/plans/2026-05-17-benchmark-dashboard.md`. Modeled after `https://iii-hq.github.io/iii/dev/bench/`.

## Design notes

- `permissions: contents: write` only — `benchmark-action/github-action-benchmark@v1` needs it to push to `gh-pages`.
- `concurrency.cancel-in-progress: false` so back-to-back tags both record a history point.
- `alert-threshold: 150%` + `fail-on-alert: false` → regressions post a commit comment but never block the release pipeline.
- `workflow_dispatch.num_runs` defaults to `20` (intentionally below the script default of `100`) to keep CI runtime bounded; overridable per run.
- Poetry installed via `snok/install-poetry@v1` matching `ci.yml`.

## Post-merge steps (manual)

1. **Actions → Benchmark → Run workflow** on `main`, e.g. `num_clients=3`, `num_runs=5` for a smoke run.
2. Confirm the action creates the `gh-pages` branch (`git fetch origin gh-pages`).
3. **Settings → Pages**: set source to `gh-pages` branch, root.
4. Open `https://guibeira.github.io/datastore-emulator/dev/bench/` to verify the dashboard renders.
5. (Optional) Reset `dev/bench/data.js` on `gh-pages` if you want a clean history before the first real `v*` tag.

## Test plan

- [x] `poetry run pytest tests/test_benchmark_json_output.py -v` → 4 passing locally
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark.yml'))"` parses
- [x] `poetry run python benchmark/test_benchmark.py --help` shows the new `--json-out` flag
- [ ] Manual `workflow_dispatch` smoke run after merge (small `num_clients` / `num_runs`)
- [ ] Enable GitHub Pages on `gh-pages` branch and confirm dashboard URL renders