### PR TITLE
Fix datastore import input handling

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -627,11 +627,22 @@ fn convert_reference_value_to_key(reference_value: &ReferenceValue) -> Key {
 
     Key {
         partition_id: Some(PartitionId {
-            project_id: reference_value.app.clone(),
+            project_id: normalize_app_id(&reference_value.app),
             namespace_id: reference_value.name_space.clone().unwrap_or_default(),
             database_id: "".to_string(),
         }),
         path,
+    }
+}
+
+/// Legacy GAE app IDs are prefixed with a partition specifier (`s~`, `e~`,
+/// `dev~`). Datastore v1 callers use the bare project_id, so strip the
+/// prefix when present.
+fn normalize_app_id(app: &str) -> String {
+    if let Some(idx) = app.find('~') {
+        app[idx + 1..].to_string()
+    } else {
+        app.to_string()
     }
 }
 
@@ -655,7 +666,7 @@ fn convert_reference_to_key(reference: &Reference) -> Key {
 
     Key {
         partition_id: Some(PartitionId {
-            project_id: reference.app.clone(),
+            project_id: normalize_app_id(&reference.app),
             namespace_id: reference.name_space.clone().unwrap_or_default(),
             database_id: "".to_string(),
         }),
@@ -739,6 +750,34 @@ pub fn converter_dump(dump_entities: Vec<EntityProto>) -> Vec<EntityWithMetadata
             }
         })
         .collect()
+}
+
+fn rewrite_key_project_id(key: &mut Key, project_id: &str) {
+    if let Some(partition) = key.partition_id.as_mut() {
+        partition.project_id = project_id.to_string();
+    }
+}
+
+fn rewrite_value_project_id(value: &mut Value, project_id: &str) {
+    match value.value_type.as_mut() {
+        Some(ValueType::KeyValue(key)) => rewrite_key_project_id(key, project_id),
+        Some(ValueType::ArrayValue(array)) => {
+            for value in array.values.iter_mut() {
+                rewrite_value_project_id(value, project_id);
+            }
+        }
+        Some(ValueType::EntityValue(entity)) => rewrite_entity_project_id(entity, project_id),
+        _ => {}
+    }
+}
+
+fn rewrite_entity_project_id(entity: &mut Entity, project_id: &str) {
+    if let Some(key) = entity.key.as_mut() {
+        rewrite_key_project_id(key, project_id);
+    }
+    for value in entity.properties.values_mut() {
+        rewrite_value_project_id(value, project_id);
+    }
 }
 
 pub fn read_overall_metadata(export_dir: &str) -> Option<OverallExportMetadata> {
@@ -1674,8 +1713,26 @@ impl DatastoreStorage {
     }
 
     pub fn import_dump(&mut self, path: &str) -> Result<(), tonic::Status> {
+        self.import_dump_for_project(path, None)
+    }
+
+    /// Import a Cloud Datastore export from `path`. If `target_project_id` is
+    /// `Some`, imported entity keys and key-valued properties are rewritten to
+    /// that value. This lets exports from prod be ingested into the local
+    /// emulator under a different project_id (the one the caller queries
+    /// with).
+    pub fn import_dump_for_project(
+        &mut self,
+        path: &str,
+        target_project_id: Option<&str>,
+    ) -> Result<(), tonic::Status> {
         let dump_entities = read_dump(path);
-        let entities_with_metadata = converter_dump(dump_entities);
+        let mut entities_with_metadata = converter_dump(dump_entities);
+        if let Some(project_id) = target_project_id {
+            for ewm in entities_with_metadata.iter_mut() {
+                rewrite_entity_project_id(&mut ewm.entity, project_id);
+            }
+        }
         tracing::info!(
             "Importing {} entities from dump at {}",
             entities_with_metadata.len(),
@@ -2686,5 +2743,201 @@ impl DatastoreStorage {
         self.remove_ancestor_indexes(&key_struct_to_delete);
         self.remove_scoped_entity(&key_struct_to_delete);
         Some(removed_entity_metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::google::datastore::import_export::datastore_v3::{
+        Path as LegacyPath, Property, PropertyValue, path, property_value,
+        property_value::reference_value,
+    };
+    use crate::google::datastore::import_export::dsbackups::{
+        ExportMetadataEntry, ExportMetadataEntryKind, ExportMetadataItems,
+    };
+    use std::path::{Path, PathBuf};
+
+    const LOCAL_PROJECT: &str = "local-project";
+    const SOURCE_PROJECT: &str = "source-project";
+
+    fn legacy_path(kind: &str, name: &str) -> LegacyPath {
+        LegacyPath {
+            element: vec![path::Element {
+                r#type: kind.to_string(),
+                id: None,
+                name: Some(name.to_string()),
+            }],
+        }
+    }
+
+    fn legacy_reference(app: &str, kind: &str, name: &str) -> Reference {
+        Reference {
+            app: app.to_string(),
+            name_space: None,
+            path: legacy_path(kind, name),
+        }
+    }
+
+    fn legacy_entity(app: &str, kind: &str, name: &str) -> EntityProto {
+        EntityProto {
+            key: legacy_reference(app, kind, name),
+            entity_group: LegacyPath { element: vec![] },
+            owner: None,
+            kind: None,
+            kind_uri: None,
+            property: vec![],
+            raw_property: vec![],
+            rank: None,
+        }
+    }
+
+    fn reference_property(name: &str, app: &str, kind: &str, entity_name: &str) -> Property {
+        Property {
+            meaning: None,
+            meaning_uri: None,
+            name: name.to_string(),
+            value: PropertyValue {
+                int64_value: None,
+                boolean_value: None,
+                string_value: None,
+                double_value: None,
+                pointvalue: None,
+                uservalue: None,
+                referencevalue: Some(property_value::ReferenceValue {
+                    app: app.to_string(),
+                    name_space: None,
+                    pathelement: vec![reference_value::PathElement {
+                        r#type: kind.to_string(),
+                        id: None,
+                        name: Some(entity_name.to_string()),
+                    }],
+                }),
+            },
+            multiple: false,
+            searchable: Some(true),
+            fts_tokenization_option: None,
+            locale: None,
+        }
+    }
+
+    fn key_project_id(entity: &Entity) -> &str {
+        &entity
+            .key
+            .as_ref()
+            .unwrap()
+            .partition_id
+            .as_ref()
+            .unwrap()
+            .project_id
+    }
+
+    fn key_property_project_id<'a>(entity: &'a Entity, name: &str) -> &'a str {
+        let Some(ValueType::KeyValue(key)) =
+            entity.properties.get(name).unwrap().value_type.as_ref()
+        else {
+            panic!("expected key-valued property {name}");
+        };
+        &key.partition_id.as_ref().unwrap().project_id
+    }
+
+    fn temp_export_root() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "datastore-emulator-import-project-test-{}",
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    fn write_leveldb_full_record(path: &Path, data: &[u8]) {
+        let mut record = Vec::with_capacity(7 + data.len());
+        record.extend_from_slice(&0u32.to_le_bytes());
+        record.extend_from_slice(&(data.len() as u16).to_le_bytes());
+        record.push(1);
+        record.extend_from_slice(data);
+        std::fs::write(path, record).unwrap();
+    }
+
+    fn write_minimal_export(root: &Path, entity: EntityProto) {
+        let exports_dir = root.join("exports");
+        let kind_dir = exports_dir.join("all_namespaces");
+        std::fs::create_dir_all(&kind_dir).unwrap();
+
+        let metadata_path = "all_namespaces/kind_Task.export_metadata";
+        let overall = OverallExportMetadata {
+            exports: vec![ExportMetadataEntry {
+                kind: Some(ExportMetadataEntryKind {
+                    unknown1: 0,
+                    kind: "Task".to_string(),
+                    unknown2: 0,
+                }),
+                path: metadata_path.to_string(),
+                count: 1,
+                size: 0,
+            }],
+        };
+        write_leveldb_full_record(
+            &exports_dir.join("all_namespaces_kind_Task.overall_export_metadata"),
+            &overall.encode_to_vec(),
+        );
+
+        let export_metadata = ExportMetadata {
+            operation: None,
+            items: Some(ExportMetadataItems {
+                kind: "Task".to_string(),
+                outputs: vec!["output-0".to_string()],
+            }),
+        };
+        std::fs::write(
+            exports_dir.join(metadata_path),
+            export_metadata.encode_to_vec(),
+        )
+        .unwrap();
+
+        write_leveldb_full_record(&kind_dir.join("output-0"), &entity.encode_to_vec());
+    }
+
+    #[test]
+    fn converter_dump_normalizes_legacy_app_ids_for_keys_and_reference_properties() {
+        let mut entity = legacy_entity("s~source-project", "Task", "one");
+        entity.property.push(reference_property(
+            "owner",
+            "s~source-project",
+            "Owner",
+            "owner-one",
+        ));
+
+        let converted = converter_dump(vec![entity]);
+        let entity = &converted[0].entity;
+
+        assert_eq!(key_project_id(entity), SOURCE_PROJECT);
+        assert_eq!(key_property_project_id(entity, "owner"), SOURCE_PROJECT);
+    }
+
+    #[test]
+    fn import_dump_for_project_rewrites_entity_and_reference_property_projects() {
+        let root = temp_export_root();
+        let mut entity = legacy_entity(SOURCE_PROJECT, "Task", "one");
+        entity.property.push(reference_property(
+            "owner",
+            SOURCE_PROJECT,
+            "Owner",
+            "owner-one",
+        ));
+        write_minimal_export(&root, entity);
+
+        let mut storage = DatastoreStorage::default();
+        storage
+            .import_dump_for_project(root.to_str().unwrap(), Some(LOCAL_PROJECT))
+            .unwrap();
+
+        let stored_entity = &storage.entities.values().next().unwrap().entity;
+        assert_eq!(storage.entities.len(), 1);
+        assert_eq!(key_project_id(stored_entity), LOCAL_PROJECT);
+        assert_eq!(
+            key_property_project_id(stored_entity, "owner"),
+            LOCAL_PROJECT
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -780,11 +780,13 @@ fn rewrite_entity_project_id(entity: &mut Entity, project_id: &str) {
     }
 }
 
-pub fn read_overall_metadata(export_dir: &str) -> Option<OverallExportMetadata> {
+type ImportReadResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+pub fn read_overall_metadata(export_dir: &str) -> ImportReadResult<OverallExportMetadata> {
     let mut metadata_file = None;
     let path_to_search = std::path::Path::new(export_dir).join("exports");
-    for entry in std::fs::read_dir(path_to_search).expect("Failed to read export directory") {
-        let entry = entry.expect("Failed to read directory entry");
+    for entry in std::fs::read_dir(&path_to_search)? {
+        let entry = entry?;
         if entry
             .file_name()
             .to_string_lossy()
@@ -795,158 +797,101 @@ pub fn read_overall_metadata(export_dir: &str) -> Option<OverallExportMetadata> 
         }
     }
 
-    let _metadata_file = metadata_file.expect("Could not find .overall_export_metadata file.");
-    tracing::debug!("Found metadata file: {}", _metadata_file.display());
-    // let reader = LogReader::new(_metadata_file.clone())
-    //     .expect("Failed to create LogReader for metadata file");
-    // dbg!("LogReader created for metadata file:", reader);
-    match LogReader::new(_metadata_file.clone()) {
-        Ok(reader) => {
-            for (i, record_result) in reader.enumerate() {
-                match record_result {
-                    Ok(record) => {
-                        match OverallExportMetadata::decode(&record[..]) {
-                            Ok(metadata) => {
-                                // Now you have the decoded 'metadata'.
-                                // You might want to process or store it.
-                                return Some(metadata); // Returning the metadata
-                            }
-                            Err(decode_err) => {
-                                tracing::error!(
-                                    "Failed to decode OverallExportMetadata: {}",
-                                    decode_err
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("Error reading record {}: {}", i + 1, e); // Translated eprintln
-                        break;
-                    }
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!("Error opening file: {}", e);
-        }
+    let metadata_file = metadata_file.ok_or_else(|| {
+        format!(
+            "Could not find .overall_export_metadata file in {}",
+            path_to_search.display()
+        )
+    })?;
+    tracing::debug!("Found metadata file: {}", metadata_file.display());
+
+    let reader = LogReader::new(&metadata_file)?;
+    for record_result in reader {
+        let record = record_result?;
+        return OverallExportMetadata::decode(&record[..])
+            .map_err(|e| format!("Failed to decode OverallExportMetadata: {}", e).into());
     }
-    None // Returning None as we are not returning the metadata here
+
+    Err(format!(
+        "No records found in overall metadata file {}",
+        metadata_file.display()
+    )
+    .into())
 }
 
-pub fn read_dump(export_dir: &str) -> Vec<EntityProto> {
+pub fn read_dump(export_dir: &str) -> ImportReadResult<Vec<EntityProto>> {
     tracing::info!("Reading datastore export from: {}", export_dir);
-    let overall_metadata = read_overall_metadata(export_dir);
-    if let Some(metadata) = overall_metadata {
-        let entity_protos: Vec<EntityProto> = metadata
-            .exports
-            .into_par_iter()
-            .flat_map(|export_entry| {
-                let kind_name = export_entry
-                    .kind
-                    .as_ref()
-                    .map_or_else(String::new, |k| k.kind.clone());
-                tracing::info!("Processing kind: {}", kind_name);
-                let metadata_path = std::path::PathBuf::from(export_dir)
-                    .join("exports")
-                    .join(&export_entry.path);
+    let metadata = read_overall_metadata(export_dir)?;
+    let mut entity_protos = Vec::new();
 
-                if !metadata_path.exists() {
-                    tracing::error!(
-                        "Metadata file for kind {} not found at: {}",
-                        kind_name,
-                        metadata_path.display()
-                    );
-                    return Vec::new().into_par_iter();
-                }
+    for export_entry in metadata.exports {
+        let kind_name = export_entry
+            .kind
+            .as_ref()
+            .map_or_else(String::new, |k| k.kind.clone());
+        tracing::info!("Processing kind: {}", kind_name);
+        let metadata_path = std::path::PathBuf::from(export_dir)
+            .join("exports")
+            .join(&export_entry.path);
 
-                let export_metadata = match std::fs::read(&metadata_path)
-                    .map_err(|e| {
-                        tracing::error!(
-                            "Failed to read metadata file {}: {}",
-                            metadata_path.display(),
-                            e
-                        );
+        if !metadata_path.exists() {
+            return Err(format!(
+                "Metadata file for kind {} not found at: {}",
+                kind_name,
+                metadata_path.display()
+            )
+            .into());
+        }
+
+        let data = std::fs::read(&metadata_path).map_err(|e| {
+            format!(
+                "Failed to read metadata file {}: {}",
+                metadata_path.display(),
+                e
+            )
+        })?;
+        let export_metadata = ExportMetadata::decode(&data[..])
+            .map_err(|e| format!("Failed to decode ExportMetadata for {}: {}", kind_name, e))?;
+
+        let output_file_names = export_metadata.items.unwrap_or_default().outputs;
+        let parent_dir_for_output_files = metadata_path
+            .parent()
+            .ok_or_else(|| format!("Metadata path has no parent: {}", metadata_path.display()))?
+            .to_path_buf();
+
+        for output_file_name_str in output_file_names {
+            let output_file_path = parent_dir_for_output_files.join(output_file_name_str);
+            if !output_file_path.exists() {
+                return Err(
+                    format!("Output file {} does not exist.", output_file_path.display()).into(),
+                );
+            }
+
+            let reader = LogReader::new(&output_file_path)
+                .map_err(|e| format!("Error opening file {}: {}", output_file_path.display(), e))?;
+            for (i, record_result) in reader.enumerate() {
+                let record = record_result.map_err(|e| {
+                    format!(
+                        "Error reading record {} from file {}: {}",
+                        i + 1,
+                        output_file_path.display(),
                         e
-                    })
-                    .and_then(|data| {
-                        ExportMetadata::decode(&data[..]).map_err(|e| {
-                            tracing::error!(
-                                "Failed to decode ExportMetadata for {}: {}",
-                                kind_name,
-                                e
-                            );
-                            std::io::Error::new(std::io::ErrorKind::InvalidData, e)
-                        })
-                    }) {
-                    Ok(meta) => meta,
-                    Err(_) => return Vec::new().into_par_iter(),
-                };
-
-                let output_file_names = export_metadata.items.unwrap_or_default().outputs;
-                let parent_dir_for_output_files = metadata_path
-                    .parent()
-                    .expect("Metadata path should have a parent directory")
-                    .to_path_buf();
-
-                let protos_for_this_export: Vec<EntityProto> = output_file_names
-                    .into_par_iter()
-                    .flat_map(move |output_file_name_str| {
-                        let output_file_path =
-                            parent_dir_for_output_files.join(output_file_name_str);
-                        let mut protos_in_file = Vec::new();
-                        if output_file_path.exists() {
-                            if let Ok(reader) = LogReader::new(output_file_path.clone()) {
-                                for (i, record_result) in reader.enumerate() {
-                                    match record_result {
-                                        Ok(record) => {
-                                            if let Ok(entity_proto) =
-                                                EntityProto::decode(&record[..])
-                                            {
-                                                protos_in_file.push(entity_proto);
-                                            } else {
-                                                tracing::error!(
-                                                    "Failed to decode EntityProto from file {}",
-                                                    output_file_path.display()
-                                                );
-                                            }
-                                        }
-                                        Err(e) => {
-                                            tracing::error!(
-                                                "Error reading record {} from file {}: {}",
-                                                i + 1,
-                                                output_file_path.display(),
-                                                e
-                                            );
-                                            break;
-                                        }
-                                    }
-                                }
-                            } else {
-                                tracing::error!(
-                                    "Error opening file: {}",
-                                    output_file_path.display()
-                                );
-                            }
-                        } else {
-                            tracing::error!(
-                                "Output file {} does not exist.",
-                                output_file_path.display()
-                            );
-                        }
-                        protos_in_file
-                    })
-                    .collect();
-
-                protos_for_this_export.into_par_iter()
-            })
-            .collect();
-
-        tracing::info!("Finished reading datastore export.");
-        entity_protos
-    } else {
-        tracing::warn!("No overall metadata found in the export directory.");
-        Vec::new()
+                    )
+                })?;
+                let entity_proto = EntityProto::decode(&record[..]).map_err(|e| {
+                    format!(
+                        "Failed to decode EntityProto from file {}: {}",
+                        output_file_path.display(),
+                        e
+                    )
+                })?;
+                entity_protos.push(entity_proto);
+            }
+        }
     }
+
+    tracing::info!("Finished reading datastore export.");
+    Ok(entity_protos)
 }
 
 #[derive(
@@ -1726,7 +1671,9 @@ impl DatastoreStorage {
         path: &str,
         target_project_id: Option<&str>,
     ) -> Result<(), tonic::Status> {
-        let dump_entities = read_dump(path);
+        let dump_entities = read_dump(path).map_err(|e| {
+            tonic::Status::invalid_argument(format!("Failed to read datastore export: {}", e))
+        })?;
         let mut entities_with_metadata = converter_dump(dump_entities);
         if let Some(project_id) = target_project_id {
             for ewm in entities_with_metadata.iter_mut() {
@@ -2936,6 +2883,26 @@ mod tests {
         assert_eq!(
             key_property_project_id(stored_entity, "owner"),
             LOCAL_PROJECT
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn import_dump_for_project_fails_when_export_metadata_is_missing() {
+        let root = temp_export_root();
+        std::fs::create_dir_all(root.join("exports")).unwrap();
+
+        let mut storage = DatastoreStorage::default();
+        let status = storage
+            .import_dump_for_project(root.to_str().unwrap(), Some(LOCAL_PROJECT))
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status
+                .message()
+                .contains("Could not find .overall_export_metadata")
         );
 
         std::fs::remove_dir_all(root).unwrap();

--- a/src/database.rs
+++ b/src/database.rs
@@ -782,6 +782,37 @@ fn rewrite_entity_project_id(entity: &mut Entity, project_id: &str) {
 
 type ImportReadResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+fn validate_export_relative_path(
+    raw_path: &str,
+    description: &str,
+) -> ImportReadResult<std::path::PathBuf> {
+    if raw_path.is_empty() {
+        return Err(format!("{} path is empty", description).into());
+    }
+    if raw_path.starts_with('/') || raw_path.starts_with('\\') || raw_path.contains('\\') {
+        return Err(format!(
+            "{} path must be a relative slash-separated path: {}",
+            description, raw_path
+        )
+        .into());
+    }
+
+    let path = std::path::Path::new(raw_path);
+    if path.is_absolute()
+        || !path
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(format!(
+            "{} path must not contain root, current, or parent components: {}",
+            description, raw_path
+        )
+        .into());
+    }
+
+    Ok(path.to_path_buf())
+}
+
 pub fn read_overall_metadata(export_dir: &str) -> ImportReadResult<OverallExportMetadata> {
     let mut metadata_file = None;
     let path_to_search = std::path::Path::new(export_dir).join("exports");
@@ -830,9 +861,11 @@ pub fn read_dump(export_dir: &str) -> ImportReadResult<Vec<EntityProto>> {
             .as_ref()
             .map_or_else(String::new, |k| k.kind.clone());
         tracing::info!("Processing kind: {}", kind_name);
+        let metadata_relative_path =
+            validate_export_relative_path(&export_entry.path, "Export metadata")?;
         let metadata_path = std::path::PathBuf::from(export_dir)
             .join("exports")
-            .join(&export_entry.path);
+            .join(metadata_relative_path);
 
         if !metadata_path.exists() {
             return Err(format!(
@@ -853,14 +886,19 @@ pub fn read_dump(export_dir: &str) -> ImportReadResult<Vec<EntityProto>> {
         let export_metadata = ExportMetadata::decode(&data[..])
             .map_err(|e| format!("Failed to decode ExportMetadata for {}: {}", kind_name, e))?;
 
-        let output_file_names = export_metadata.items.unwrap_or_default().outputs;
+        let output_file_names = export_metadata
+            .items
+            .ok_or_else(|| format!("ExportMetadata for kind {} is missing items", kind_name))?
+            .outputs;
         let parent_dir_for_output_files = metadata_path
             .parent()
             .ok_or_else(|| format!("Metadata path has no parent: {}", metadata_path.display()))?
             .to_path_buf();
 
         for output_file_name_str in output_file_names {
-            let output_file_path = parent_dir_for_output_files.join(output_file_name_str);
+            let output_relative_path =
+                validate_export_relative_path(&output_file_name_str, "Export output")?;
+            let output_file_path = parent_dir_for_output_files.join(output_relative_path);
             if !output_file_path.exists() {
                 return Err(
                     format!("Output file {} does not exist.", output_file_path.display()).into(),
@@ -2804,12 +2842,17 @@ mod tests {
         std::fs::write(path, record).unwrap();
     }
 
-    fn write_minimal_export(root: &Path, entity: EntityProto) {
+    fn write_minimal_export_with_paths(
+        root: &Path,
+        entity: EntityProto,
+        metadata_path: &str,
+        output_path: &str,
+        include_items: bool,
+    ) {
         let exports_dir = root.join("exports");
         let kind_dir = exports_dir.join("all_namespaces");
         std::fs::create_dir_all(&kind_dir).unwrap();
 
-        let metadata_path = "all_namespaces/kind_Task.export_metadata";
         let overall = OverallExportMetadata {
             exports: vec![ExportMetadataEntry {
                 kind: Some(ExportMetadataEntryKind {
@@ -2829,9 +2872,9 @@ mod tests {
 
         let export_metadata = ExportMetadata {
             operation: None,
-            items: Some(ExportMetadataItems {
+            items: include_items.then(|| ExportMetadataItems {
                 kind: "Task".to_string(),
-                outputs: vec!["output-0".to_string()],
+                outputs: vec![output_path.to_string()],
             }),
         };
         std::fs::write(
@@ -2841,6 +2884,16 @@ mod tests {
         .unwrap();
 
         write_leveldb_full_record(&kind_dir.join("output-0"), &entity.encode_to_vec());
+    }
+
+    fn write_minimal_export(root: &Path, entity: EntityProto) {
+        write_minimal_export_with_paths(
+            root,
+            entity,
+            "all_namespaces/kind_Task.export_metadata",
+            "output-0",
+            true,
+        );
     }
 
     #[test]
@@ -2904,6 +2957,72 @@ mod tests {
                 .message()
                 .contains("Could not find .overall_export_metadata")
         );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn import_dump_for_project_fails_when_kind_metadata_items_are_missing() {
+        let root = temp_export_root();
+        write_minimal_export_with_paths(
+            &root,
+            legacy_entity(SOURCE_PROJECT, "Task", "one"),
+            "all_namespaces/kind_Task.export_metadata",
+            "output-0",
+            false,
+        );
+
+        let mut storage = DatastoreStorage::default();
+        let status = storage
+            .import_dump_for_project(root.to_str().unwrap(), Some(LOCAL_PROJECT))
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("missing items"));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn import_dump_for_project_rejects_unsafe_export_metadata_path() {
+        let root = temp_export_root();
+        write_minimal_export_with_paths(
+            &root,
+            legacy_entity(SOURCE_PROJECT, "Task", "one"),
+            "../kind_Task.export_metadata",
+            "output-0",
+            true,
+        );
+
+        let mut storage = DatastoreStorage::default();
+        let status = storage
+            .import_dump_for_project(root.to_str().unwrap(), Some(LOCAL_PROJECT))
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Export metadata path"));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn import_dump_for_project_rejects_unsafe_output_path() {
+        let root = temp_export_root();
+        write_minimal_export_with_paths(
+            &root,
+            legacy_entity(SOURCE_PROJECT, "Task", "one"),
+            "all_namespaces/kind_Task.export_metadata",
+            "../output-0",
+            true,
+        );
+
+        let mut storage = DatastoreStorage::default();
+        let status = storage
+            .import_dump_for_project(root.to_str().unwrap(), Some(LOCAL_PROJECT))
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Export output path"));
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/src/import.rs
+++ b/src/import.rs
@@ -68,6 +68,7 @@ pub async fn bg_import_data(
     operations: Operations,
     operation_id: String,
     input_url: String,
+    target_project_id: Option<String>,
 ) {
     tracing::info!("Importing data from {:?} in the background...", input_url);
 
@@ -155,7 +156,7 @@ pub async fn bg_import_data(
     let start = Instant::now();
     let import_result = {
         let mut storage_guard = storage.write().await;
-        storage_guard.import_dump(&export_dir)
+        storage_guard.import_dump_for_project(&export_dir, target_project_id.as_deref())
     };
 
     let duration = start.elapsed();

--- a/src/import.rs
+++ b/src/import.rs
@@ -10,6 +10,19 @@ use std::time::Instant;
 use tokio::{io::AsyncWriteExt, sync::RwLock, task};
 use tracing;
 
+fn download_temp_path_for_object(object: &str) -> std::path::PathBuf {
+    let file_name = object
+        .split('/')
+        .next_back()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("datastore_export.zip");
+    std::env::temp_dir().join(format!(
+        "datastore-emulator-download-{}-{}",
+        uuid::Uuid::new_v4(),
+        file_name
+    ))
+}
+
 async fn download_gcs_file(
     gcs_url: &str,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
@@ -38,14 +51,8 @@ async fn download_gcs_file(
         .await
         .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
 
-    // Create a temporary file to store the download
-    let file_name = object
-        .split('/')
-        .next_back()
-        .unwrap_or("datastore_export.zip");
-    let mut temp_path = std::env::temp_dir();
-    temp_path.push(file_name);
-
+    // Create a unique temporary file to store the download.
+    let temp_path = download_temp_path_for_object(object);
     let local_path_str = temp_path.to_str().ok_or("Invalid temp path")?.to_string();
 
     let mut dest = tokio::fs::File::create(&temp_path).await?;
@@ -408,6 +415,42 @@ mod tests {
         .unwrap();
         zip.write_all(b"metadata").unwrap();
         zip.finish().unwrap();
+    }
+
+    #[test]
+    fn download_temp_path_for_object_is_unique_and_preserves_basename() {
+        let first = download_temp_path_for_object("exports/backup.zip");
+        let second = download_temp_path_for_object("exports/backup.zip");
+
+        assert_ne!(first, second);
+        assert!(
+            first
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("datastore-emulator-download-")
+        );
+        assert!(
+            first
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .ends_with("backup.zip")
+        );
+    }
+
+    #[test]
+    fn download_temp_path_for_metadata_object_preserves_metadata_suffix() {
+        let path = download_temp_path_for_object(
+            "exports/all_namespaces_kind_Task.overall_export_metadata",
+        );
+
+        assert!(
+            path.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .ends_with(".overall_export_metadata")
+        );
     }
 
     #[test]

--- a/src/import.rs
+++ b/src/import.rs
@@ -104,6 +104,25 @@ pub async fn bg_import_data(
         input_url.clone()
     };
 
+    let cleanup_downloaded_file = |path: String| async move {
+        let cleanup_path = path.clone();
+        match task::spawn_blocking(move || std::fs::remove_file(&cleanup_path)).await {
+            Ok(Ok(())) => {
+                tracing::info!("Temporary downloaded file {} removed.", path);
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("Failed to remove temporary downloaded file {}: {}", path, e);
+            }
+            Err(join_err) => {
+                tracing::warn!(
+                    "Cleanup task for temporary file {} failed: {}",
+                    path,
+                    join_err
+                );
+            }
+        }
+    };
+
     let prepare_result = task::spawn_blocking({
         let path = local_file_path.clone();
         move || prepare_export_dir(path)
@@ -135,6 +154,9 @@ pub async fn bg_import_data(
                     local_file_path, e
                 ));
             }
+            if downloaded_from_gcs {
+                cleanup_downloaded_file(local_file_path.clone()).await;
+            }
             return;
         }
         Err(join_err) => {
@@ -148,6 +170,9 @@ pub async fn bg_import_data(
                 state.status = OperationStatus::Failed;
                 state.end_time = Some(Utc::now());
                 state.error = Some("Background preparation task failed".to_string());
+            }
+            if downloaded_from_gcs {
+                cleanup_downloaded_file(local_file_path.clone()).await;
             }
             return;
         }
@@ -210,26 +235,7 @@ pub async fn bg_import_data(
     }
 
     if downloaded_from_gcs {
-        let cleanup_path = local_file_path.clone();
-        match task::spawn_blocking(move || std::fs::remove_file(&cleanup_path)).await {
-            Ok(Ok(())) => {
-                tracing::info!("Temporary downloaded file {} removed.", local_file_path);
-            }
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    "Failed to remove temporary downloaded file {}: {}",
-                    local_file_path,
-                    e
-                );
-            }
-            Err(join_err) => {
-                tracing::warn!(
-                    "Cleanup task for temporary file {} failed: {}",
-                    local_file_path,
-                    join_err
-                );
-            }
-        }
+        cleanup_downloaded_file(local_file_path.clone()).await;
     }
 
     tracing::info!("Background import completed.");
@@ -240,8 +246,8 @@ pub async fn bg_import_data(
 /// `export_dir` is a path suitable for `DatastoreStorage::import_dump`, i.e. it
 /// satisfies `<export_dir>/exports/<name>.overall_export_metadata`.
 ///
-/// `extracted_dump` is `true` when this function extracted a zip archive into
-/// `./dump` and the caller is expected to clean it up.
+/// `extracted_dump` is `true` when this function extracted a zip archive into a
+/// temporary directory and the caller is expected to clean it up.
 ///
 /// Accepted input formats:
 ///   * A zip archive (`*.zip` or magic-byte detected) that contains an
@@ -271,8 +277,12 @@ fn prepare_export_dir(
         }
 
         if is_zip_file(path)? {
-            extract_zip_to_dump(path)?;
-            return Ok(("dump".to_string(), true));
+            let dump_path = unique_dump_dir();
+            if let Err(e) = extract_zip_to_dir(path, &dump_path) {
+                let _ = std::fs::remove_dir_all(&dump_path);
+                return Err(e);
+            }
+            return Ok((dump_path.to_string_lossy().into_owned(), true));
         }
 
         return Err(format!(
@@ -325,10 +335,14 @@ fn contains_overall_metadata(dir: &std::path::Path) -> Result<bool, std::io::Err
     Ok(false)
 }
 
-fn extract_zip_to_dump(
+fn unique_dump_dir() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("datastore-emulator-dump-{}", uuid::Uuid::new_v4()))
+}
+
+fn extract_zip_to_dir(
     zip_path: &std::path::Path,
+    dump_path: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let dump_path = std::path::Path::new("dump");
     if dump_path.exists() {
         std::fs::remove_dir_all(dump_path)?;
     }
@@ -355,6 +369,7 @@ fn extract_zip_to_dump(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use std::path::{Path, PathBuf};
 
     fn temp_export_root() -> PathBuf {
@@ -374,6 +389,25 @@ mod tests {
 
     fn assert_prepared_path_eq(actual: String, expected: &Path) {
         assert_eq!(PathBuf::from(actual), expected);
+    }
+
+    fn temp_zip_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "datastore-emulator-import-test-{}.zip",
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    fn write_export_zip(path: &Path) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file(
+            "exports/all_namespaces_kind_Task.overall_export_metadata",
+            zip::write::SimpleFileOptions::default(),
+        )
+        .unwrap();
+        zip.write_all(b"metadata").unwrap();
+        zip.finish().unwrap();
     }
 
     #[test]
@@ -417,5 +451,39 @@ mod tests {
         assert!(!extracted_dump);
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn prepare_export_dir_extracts_zip_to_unique_temp_directory() {
+        let zip_path = temp_zip_path();
+        write_export_zip(&zip_path);
+
+        let (first_dir, first_extracted) =
+            prepare_export_dir(zip_path.to_string_lossy().into_owned()).unwrap();
+        let (second_dir, second_extracted) =
+            prepare_export_dir(zip_path.to_string_lossy().into_owned()).unwrap();
+
+        let first_path = PathBuf::from(&first_dir);
+        let second_path = PathBuf::from(&second_dir);
+        assert!(first_extracted);
+        assert!(second_extracted);
+        assert_ne!(first_path, PathBuf::from("dump"));
+        assert_ne!(first_path, second_path);
+        assert!(
+            first_path
+                .join("exports")
+                .join("all_namespaces_kind_Task.overall_export_metadata")
+                .exists()
+        );
+        assert!(
+            second_path
+                .join("exports")
+                .join("all_namespaces_kind_Task.overall_export_metadata")
+                .exists()
+        );
+
+        std::fs::remove_dir_all(first_path).unwrap();
+        std::fs::remove_dir_all(second_path).unwrap();
+        std::fs::remove_file(zip_path).unwrap();
     }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -103,30 +103,42 @@ pub async fn bg_import_data(
         input_url.clone()
     };
 
-    let folder_name = "dump";
-    let extraction_result = task::spawn_blocking({
+    let prepare_result = task::spawn_blocking({
         let path = local_file_path.clone();
-        move || extract_file(path)
+        move || prepare_export_dir(path)
     })
     .await;
 
-    match extraction_result {
-        Ok(Ok(())) => {
-            tracing::info!("File {:?} extracted successfully.", local_file_path);
+    let (export_dir, extracted_dump) = match prepare_result {
+        Ok(Ok(result)) => {
+            tracing::info!(
+                "Prepared export dir {:?} from input {:?} (extracted_dump={})",
+                result.0,
+                local_file_path,
+                result.1
+            );
+            result
         }
         Ok(Err(e)) => {
-            tracing::error!("Failed to extract file {:?}: {}", local_file_path, e);
+            tracing::error!(
+                "Failed to prepare export dir from {:?}: {}",
+                local_file_path,
+                e
+            );
             let mut operations = operations.write().await;
             if let Some(state) = operations.get_mut(&operation_id) {
                 state.status = OperationStatus::Failed;
                 state.end_time = Some(Utc::now());
-                state.error = Some(format!("Failed to extract file {}", local_file_path));
+                state.error = Some(format!(
+                    "Failed to prepare export dir from {}: {}",
+                    local_file_path, e
+                ));
             }
             return;
         }
         Err(join_err) => {
             tracing::error!(
-                "Extraction task panicked for {:?}: {}",
+                "Preparation task panicked for {:?}: {}",
                 local_file_path,
                 join_err
             );
@@ -134,16 +146,16 @@ pub async fn bg_import_data(
             if let Some(state) = operations.get_mut(&operation_id) {
                 state.status = OperationStatus::Failed;
                 state.end_time = Some(Utc::now());
-                state.error = Some("Background extraction task failed".to_string());
+                state.error = Some("Background preparation task failed".to_string());
             }
             return;
         }
-    }
+    };
 
     let start = Instant::now();
     let import_result = {
         let mut storage_guard = storage.write().await;
-        storage_guard.import_dump(folder_name)
+        storage_guard.import_dump(&export_dir)
     };
 
     let duration = start.elapsed();
@@ -181,16 +193,18 @@ pub async fn bg_import_data(
         }
     }
 
-    let folder = folder_name.to_string();
-    match task::spawn_blocking(move || std::fs::remove_dir_all(&folder)).await {
-        Ok(Ok(())) => {
-            tracing::info!("Dump directory cleaned up successfully.");
-        }
-        Ok(Err(e)) => {
-            tracing::error!("Failed to clean up dump directory: {}", e);
-        }
-        Err(join_err) => {
-            tracing::error!("Cleanup task for dump directory failed: {}", join_err);
+    if extracted_dump {
+        let folder = export_dir.clone();
+        match task::spawn_blocking(move || std::fs::remove_dir_all(&folder)).await {
+            Ok(Ok(())) => {
+                tracing::info!("Dump directory cleaned up successfully.");
+            }
+            Ok(Err(e)) => {
+                tracing::error!("Failed to clean up dump directory: {}", e);
+            }
+            Err(join_err) => {
+                tracing::error!("Cleanup task for dump directory failed: {}", join_err);
+            }
         }
     }
 
@@ -220,26 +234,187 @@ pub async fn bg_import_data(
     tracing::info!("Background import completed.");
 }
 
-fn extract_file(input_url: String) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let dump_path = std::path::Path::new("dump");
-    if !dump_path.exists() {
-        std::fs::create_dir_all(dump_path).expect("Failed to create dump directory");
+/// Inspect `input_url` and return `(export_dir, extracted_dump)`.
+///
+/// `export_dir` is a path suitable for `DatastoreStorage::import_dump`, i.e. it
+/// satisfies `<export_dir>/exports/<name>.overall_export_metadata`.
+///
+/// `extracted_dump` is `true` when this function extracted a zip archive into
+/// `./dump` and the caller is expected to clean it up.
+///
+/// Accepted input formats:
+///   * A zip archive (`*.zip` or magic-byte detected) that contains an
+///     `exports/<name>.overall_export_metadata` tree at the archive root.
+///   * A `.overall_export_metadata` LevelDB log file. The export root is the
+///     grandparent directory (metadata files live in `<root>/exports/`).
+///   * A directory that either already is the export root or contains the
+///     metadata file directly.
+fn prepare_export_dir(
+    input_url: String,
+) -> Result<(String, bool), Box<dyn std::error::Error + Send + Sync>> {
+    let path = std::path::Path::new(&input_url);
+
+    if !path.exists() {
+        return Err(format!("Input path does not exist: {}", input_url).into());
     }
-    let zip_file = std::fs::File::open(&input_url).expect("Failed to open zip file");
-    let mut archive = zip::ZipArchive::new(zip_file).expect("Failed to read zip file");
+
+    if path.is_file() {
+        if input_url.ends_with(".overall_export_metadata") {
+            let exports_dir = path
+                .parent()
+                .ok_or("Metadata file has no parent directory")?;
+            let export_root = exports_dir
+                .parent()
+                .ok_or("Metadata file parent has no parent directory")?;
+            return Ok((export_root.to_string_lossy().into_owned(), false));
+        }
+
+        if is_zip_file(path)? {
+            extract_zip_to_dump(path)?;
+            return Ok(("dump".to_string(), true));
+        }
+
+        return Err(format!(
+            "Unsupported file input (expected .zip or .overall_export_metadata): {}",
+            input_url
+        )
+        .into());
+    }
+
+    if path.is_dir() {
+        let exports_subdir = path.join("exports");
+        if exports_subdir.is_dir() && contains_overall_metadata(&exports_subdir)? {
+            return Ok((input_url, false));
+        }
+        if contains_overall_metadata(path)? {
+            let parent = path
+                .parent()
+                .ok_or("Export directory has no parent directory")?;
+            return Ok((parent.to_string_lossy().into_owned(), false));
+        }
+        return Err(format!(
+            "Directory {} does not contain a *.overall_export_metadata file",
+            input_url
+        )
+        .into());
+    }
+
+    Err(format!("Unsupported input path: {}", input_url).into())
+}
+
+fn is_zip_file(path: &std::path::Path) -> Result<bool, std::io::Error> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut magic = [0u8; 4];
+    let read = file.read(&mut magic)?;
+    Ok(read == 4 && &magic == b"PK\x03\x04")
+}
+
+fn contains_overall_metadata(dir: &std::path::Path) -> Result<bool, std::io::Error> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".overall_export_metadata")
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn extract_zip_to_dump(
+    zip_path: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let dump_path = std::path::Path::new("dump");
+    if dump_path.exists() {
+        std::fs::remove_dir_all(dump_path)?;
+    }
+    std::fs::create_dir_all(dump_path)?;
+
+    let zip_file = std::fs::File::open(zip_path)?;
+    let mut archive = zip::ZipArchive::new(zip_file)?;
     for i in 0..archive.len() {
-        let mut file = archive.by_index(i).expect("Failed to read file from zip");
+        let mut file = archive.by_index(i)?;
         let outpath = dump_path.join(file.mangled_name());
         if file.name().ends_with('/') {
-            std::fs::create_dir_all(&outpath).expect("Failed to create directory");
+            std::fs::create_dir_all(&outpath)?;
         } else {
             if let Some(p) = outpath.parent() {
-                std::fs::create_dir_all(p).expect("Failed to create parent directory");
+                std::fs::create_dir_all(p)?;
             }
-            let mut outfile =
-                std::fs::File::create(&outpath).expect("Failed to create output file");
-            std::io::copy(&mut file, &mut outfile).expect("Failed to copy file contents");
+            let mut outfile = std::fs::File::create(&outpath)?;
+            std::io::copy(&mut file, &mut outfile)?;
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn temp_export_root() -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "datastore-emulator-import-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(root.join("exports")).unwrap();
+        std::fs::write(
+            root.join("exports")
+                .join("all_namespaces_kind_Task.overall_export_metadata"),
+            b"",
+        )
+        .unwrap();
+        root
+    }
+
+    fn assert_prepared_path_eq(actual: String, expected: &Path) {
+        assert_eq!(PathBuf::from(actual), expected);
+    }
+
+    #[test]
+    fn prepare_export_dir_accepts_export_root_directory() {
+        let root = temp_export_root();
+
+        let (export_dir, extracted_dump) =
+            prepare_export_dir(root.to_string_lossy().into_owned()).unwrap();
+
+        assert_prepared_path_eq(export_dir, &root);
+        assert!(!extracted_dump);
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn prepare_export_dir_accepts_exports_directory() {
+        let root = temp_export_root();
+        let exports_dir = root.join("exports");
+
+        let (export_dir, extracted_dump) =
+            prepare_export_dir(exports_dir.to_string_lossy().into_owned()).unwrap();
+
+        assert_prepared_path_eq(export_dir, &root);
+        assert!(!extracted_dump);
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn prepare_export_dir_accepts_overall_metadata_file() {
+        let root = temp_export_root();
+        let metadata_file = root
+            .join("exports")
+            .join("all_namespaces_kind_Task.overall_export_metadata");
+
+        let (export_dir, extracted_dump) =
+            prepare_export_dir(metadata_file.to_string_lossy().into_owned()).unwrap();
+
+        assert_prepared_path_eq(export_dir, &root);
+        assert!(!extracted_dump);
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src/leveldb.rs
+++ b/src/leveldb.rs
@@ -107,6 +107,14 @@ impl LogReader {
     fn read_physical_record(&mut self) -> Result<Option<(u8, Vec<u8>)>, CorruptionError> {
         loop {
             if self.block.is_empty() || self.block.len() - self.block_offset < HEADER_SIZE {
+                if !self.block.is_empty() && self.block_offset < self.block.len() {
+                    let trailer = &self.block[self.block_offset..];
+                    if trailer.iter().any(|&b| b != 0) {
+                        return Err(CorruptionError::TruncatedRecord(
+                            "Non-zero bytes found in block trailer",
+                        ));
+                    }
+                }
                 if !self.load_next_block()? {
                     return Ok(None);
                 }
@@ -247,6 +255,25 @@ mod tests {
         assert_eq!(reader.next().unwrap().unwrap(), first);
         assert_eq!(reader.next().unwrap().unwrap(), second);
         assert!(reader.next().is_none());
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_non_zero_block_trailer() {
+        let path = temp_log_path();
+        let mut file = File::create(&path).unwrap();
+        let first = vec![b'a'; BLOCK_SIZE - HEADER_SIZE - 3];
+
+        write_full_record(&mut file, &first);
+        file.write_all(&[1, 2, 3]).unwrap();
+        drop(file);
+
+        let mut reader = LogReader::new(&path).unwrap();
+        assert_eq!(reader.next().unwrap().unwrap(), first);
+        let error = reader.next().unwrap().unwrap_err();
+        assert!(matches!(error, CorruptionError::TruncatedRecord(_)));
+        assert!(error.to_string().contains("Non-zero bytes"));
 
         std::fs::remove_file(path).unwrap();
     }

--- a/src/leveldb.rs
+++ b/src/leveldb.rs
@@ -1,7 +1,7 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::fs::File;
 use std::io::{self, Read};
-use std::path::Path; // To read integers from the buffer (analogous to struct.unpack)
+use std::path::Path;
 
 // LevelDB log format constants
 const BLOCK_SIZE: usize = 32768;
@@ -13,8 +13,6 @@ const FIRST_TYPE: u8 = 2;
 const MIDDLE_TYPE: u8 = 3;
 const LAST_TYPE: u8 = 4;
 
-/// Error enum to represent failures in reading or parsing the log.
-/// Analogous to Python's CorruptionError exception.
 #[derive(Debug)]
 pub enum CorruptionError {
     Io(io::Error),
@@ -24,7 +22,6 @@ pub enum CorruptionError {
     UnknownRecordType(u8),
 }
 
-// Implementations to make our error a standard error type in Rust.
 impl std::fmt::Display for CorruptionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -39,150 +36,132 @@ impl std::fmt::Display for CorruptionError {
     }
 }
 
-// Implementations to make our error a standard error type in Rust.
 impl std::error::Error for CorruptionError {}
 
-// Allows easy conversion of IO errors to our error type.
 impl From<io::Error> for CorruptionError {
     fn from(err: io::Error) -> Self {
         CorruptionError::Io(err)
     }
 }
 
-/// A reader for LevelDB log files.
-/// This struct holds the state, analogous to Python class attributes.
-#[derive(Debug)] // Added to resolve E0277
+/// Block-aware LevelDB log reader.
+///
+/// LevelDB log format: file is split into 32 KiB blocks. A physical record
+/// header is 7 bytes (4 CRC + 2 length + 1 type). When fewer than 7 bytes
+/// remain in a block, those bytes form a zero-filled trailer that must be
+/// skipped — no record can start there. A previous version of this reader
+/// concatenated all blocks into one flat buffer and parsed records without
+/// tracking block boundaries, which caused trailers to be misread as
+/// headers (UnknownRecordType / TruncatedRecord errors mid-file).
+#[derive(Debug)]
 pub struct LogReader {
     file: File,
-    buffer: Vec<u8>,
+    block: Vec<u8>,
+    block_offset: usize,
     eof: bool,
 }
 
 impl LogReader {
-    /// Creates a new LogReader from a file path.
-    /// Analogous to `__init__`. Returns a Result because opening the file can fail.
     pub fn new<P: AsRef<Path>>(filename: P) -> io::Result<Self> {
         let file = File::open(filename)?;
         Ok(LogReader {
             file,
-            buffer: Vec::with_capacity(BLOCK_SIZE * 2), // Pre-allocate for efficiency
+            block: Vec::new(),
+            block_offset: 0,
             eof: false,
         })
     }
 
-    /// Reads the next block from the file into the buffer.
-    /// Analogous to `_read_block`.
-    fn read_block(&mut self) -> io::Result<bool> {
+    /// Load the next 32 KiB block into `self.block`. Returns true if any
+    /// bytes were loaded.
+    fn load_next_block(&mut self) -> io::Result<bool> {
         if self.eof {
             return Ok(false);
         }
-        let mut temp_buf = [0u8; BLOCK_SIZE];
-        let bytes_read = self.file.read(&mut temp_buf)?;
-
-        if bytes_read == 0 {
+        let mut buf = vec![0u8; BLOCK_SIZE];
+        let mut total = 0;
+        while total < BLOCK_SIZE {
+            let n = self.file.read(&mut buf[total..])?;
+            if n == 0 {
+                break;
+            }
+            total += n;
+        }
+        if total == 0 {
             self.eof = true;
+            self.block.clear();
+            self.block_offset = 0;
             return Ok(false);
         }
-
-        self.buffer.extend_from_slice(&temp_buf[..bytes_read]);
+        if total < BLOCK_SIZE {
+            self.eof = true;
+            buf.truncate(total);
+        }
+        self.block = buf;
+        self.block_offset = 0;
         Ok(true)
     }
 
-    /// Reads the next physical record from the buffer.
-    /// Analogous to `_read_physical_record`.
-    /// Returns `Ok(None)` if more data is needed.
+    /// Read the next physical record, skipping block trailers. Returns
+    /// `Ok(None)` only at clean EOF.
     fn read_physical_record(&mut self) -> Result<Option<(u8, Vec<u8>)>, CorruptionError> {
-        // If the buffer is too small for a header, try to read more data.
-        if self.buffer.len() < HEADER_SIZE {
-            if !self.eof {
-                self.read_block()?;
-            }
-            // If there's still not enough data, check if it's a valid end of file.
-            if self.buffer.len() < HEADER_SIZE {
-                if self.eof && !self.buffer.is_empty() {
-                    return Err(CorruptionError::TruncatedRecord(
-                        "Truncated record header at EOF",
-                    ));
+        loop {
+            if self.block.is_empty() || self.block.len() - self.block_offset < HEADER_SIZE {
+                if !self.load_next_block()? {
+                    return Ok(None);
                 }
-                return Ok(None); // Not an error, just no more complete records.
+                continue;
             }
-        }
 
-        // Use a cursor to read from the buffer without needing to copy.
-        let mut cursor = &self.buffer[..HEADER_SIZE];
-        let checksum = cursor.read_u32::<LittleEndian>()?;
-        let length = cursor.read_u16::<LittleEndian>()? as usize;
-        let record_type = cursor.read_u8()?;
+            let start = self.block_offset;
+            let mut cursor = &self.block[start..start + HEADER_SIZE];
+            let checksum = cursor.read_u32::<LittleEndian>()?;
+            let length = cursor.read_u16::<LittleEndian>()? as usize;
+            let record_type = cursor.read_u8()?;
 
-        // If the complete record (header + data) is not in the buffer, try to read more.
-        if self.buffer.len() < HEADER_SIZE + length {
-            if !self.eof {
-                self.read_block()?;
+            // A zero record type indicates the start of a block trailer
+            // (zero-padded leftover bytes). Skip to the next block.
+            if record_type == 0 && length == 0 && checksum == 0 {
+                self.block_offset = self.block.len();
+                continue;
             }
-            if self.buffer.len() < HEADER_SIZE + length {
-                if self.eof {
-                    return Err(CorruptionError::TruncatedRecord(
-                        "Truncated record data at EOF",
-                    ));
-                }
-                return Ok(None);
+
+            let data_start = start + HEADER_SIZE;
+            let data_end = data_start + length;
+            if data_end > self.block.len() {
+                return Err(CorruptionError::TruncatedRecord(
+                    "Record length exceeds block boundary",
+                ));
             }
+
+            let data = self.block[data_start..data_end].to_vec();
+            self.block_offset = data_end;
+
+            // CRC verification intentionally skipped (mirrors prior behavior;
+            // many exports we ingest do not preserve a verifiable CRC).
+            let _ = checksum;
+
+            return Ok(Some((record_type, data)));
         }
-
-        // Extract the data and remove the physical record from the buffer.
-        let data = self.buffer[HEADER_SIZE..HEADER_SIZE + length].to_vec();
-        self.buffer.drain(..HEADER_SIZE + length);
-
-        // Verify the checksum. LevelDB's CRC32C is "masked".
-        // Although your Python code commented it out, the correct implementation is this:
-        let masked_crc = {
-            // Construct the bytes for the CRC more explicitly
-            let mut bytes_for_crc = Vec::with_capacity(1 + data.len());
-            bytes_for_crc.push(record_type); // record_type is already i8, convert to u8
-            bytes_for_crc.extend_from_slice(&data);
-            let crc = crc32c::crc32c(&bytes_for_crc);
-            crc.rotate_right(15).wrapping_add(0xa282ead8)
-        };
-
-        if checksum != masked_crc {
-            // Uncomment the line below to enable checksum verification.
-            // return Err(CorruptionError::ChecksumMismatch);
-        }
-
-        Ok(Some((record_type, data))) // Converted record_type to u8 to match the function signature
     }
 
-    /// Reads the next logical record (which may be fragmented).
-    /// This function is called by `next()` and contains the main iterator logic.
     fn read_logical_record(&mut self) -> Option<Result<Vec<u8>, CorruptionError>> {
-        // Analogous to `if self._eof and not self._buffer: raise StopIteration`
-        if self.eof && self.buffer.is_empty() {
-            return None;
-        }
-
         let mut fragments: Vec<Vec<u8>> = Vec::new();
         loop {
             let physical_record = match self.read_physical_record() {
                 Ok(Some(record)) => record,
-                // `Ok(None)` means we need more data or have reached a clean end.
                 Ok(None) => {
-                    if self.eof && self.buffer.is_empty() {
-                        if !fragments.is_empty() {
-                            return Some(Err(CorruptionError::InvalidFragmentSequence(
-                                "Log file ended in the middle of a fragmented record",
-                            )));
-                        }
-                        return None; // End of iteration
+                    if !fragments.is_empty() {
+                        return Some(Err(CorruptionError::InvalidFragmentSequence(
+                            "Log file ended in the middle of a fragmented record",
+                        )));
                     }
-                    // If not EOF, the loop continues to try to read more in `read_physical_record`.
-                    // This is safe because `read_physical_record` calls `read_block`.
-                    continue;
+                    return None;
                 }
                 Err(e) => return Some(Err(e)),
             };
 
             let (record_type, data) = physical_record;
-
             match record_type {
                 FULL_TYPE => {
                     if !fragments.is_empty() {
@@ -223,13 +202,52 @@ impl LogReader {
     }
 }
 
-/// Implements the Iterator trait to make the struct easy to use in `for` loops.
-/// Analogous to `__iter__` and `__next__`.
 impl Iterator for LogReader {
-    // The iterator will produce either a record (`Vec<u8>`) or an error.
     type Item = Result<Vec<u8>, CorruptionError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.read_logical_record()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use byteorder::{LittleEndian, WriteBytesExt};
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn temp_log_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "datastore-emulator-leveldb-test-{}.log",
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    fn write_full_record(file: &mut File, data: &[u8]) {
+        file.write_u32::<LittleEndian>(0).unwrap();
+        file.write_u16::<LittleEndian>(data.len() as u16).unwrap();
+        file.write_u8(FULL_TYPE).unwrap();
+        file.write_all(data).unwrap();
+    }
+
+    #[test]
+    fn reads_record_after_block_trailer() {
+        let path = temp_log_path();
+        let mut file = File::create(&path).unwrap();
+        let first = vec![b'a'; BLOCK_SIZE - HEADER_SIZE - 3];
+        let second = b"after-trailer";
+
+        write_full_record(&mut file, &first);
+        file.write_all(&[0; 3]).unwrap();
+        write_full_record(&mut file, second);
+        drop(file);
+
+        let mut reader = LogReader::new(&path).unwrap();
+        assert_eq!(reader.next().unwrap().unwrap(), first);
+        assert_eq!(reader.next().unwrap().unwrap(), second);
+        assert!(reader.next().is_none());
+
+        std::fs::remove_file(path).unwrap();
     }
 }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -156,12 +156,26 @@ pub async fn import_handler(state: AppState, project_id: String, body: Bytes) ->
         .await
         .insert(operation_id.clone(), operation_state);
 
-    tokio::spawn(bg_import_data(
+    bg_import_data(
         state.storage.clone(),
         state.operations.clone(),
         operation_id.clone(),
         payload.input_url.clone(),
-    ));
+    )
+    .await;
+
+    let final_state = state
+        .operations
+        .read()
+        .await
+        .get(&operation_id)
+        .map(|s| match s.status {
+            OperationStatus::Successful => "SUCCESSFUL",
+            OperationStatus::Failed => "FAILED",
+            OperationStatus::Processing => "PROCESSING",
+        })
+        .unwrap_or("PROCESSING")
+        .to_string();
 
     let response = ImportResponse {
         name: format!("projects/{}/operations/{}", project_id, operation_id),
@@ -171,7 +185,7 @@ pub async fn import_handler(state: AppState, project_id: String, body: Bytes) ->
             common: CommonMetadata {
                 start_time: Utc::now().to_rfc3339(),
                 operation_type: "IMPORT_ENTITIES".to_string(),
-                state: "PROCESSING".to_string(),
+                state: final_state,
             },
             entity_filter: serde_json::json!({}),
             input_url: payload.input_url,
@@ -568,9 +582,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["metadata"]["common"]["state"], "FAILED");
 
-        // operation registered
-        assert_eq!(state.operations.read().await.len(), 1);
+        let operations = state.operations.read().await;
+        assert_eq!(operations.len(), 1);
+        let operation = operations.values().next().unwrap();
+        assert!(matches!(operation.status.clone(), OperationStatus::Failed));
+        assert!(operation
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("File not found"));
     }
 
     #[tokio::test]

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -144,9 +144,10 @@ pub async fn import_handler(state: AppState, project_id: String, body: Bytes) ->
     };
 
     let operation_id = Uuid::new_v4().to_string();
+    let operation_start_time = Utc::now();
     let operation_state = OperationState {
         status: OperationStatus::Processing,
-        start_time: Utc::now(),
+        start_time: operation_start_time.clone(),
         end_time: None,
         error: None,
     };
@@ -165,18 +166,20 @@ pub async fn import_handler(state: AppState, project_id: String, body: Bytes) ->
     )
     .await;
 
-    let final_state = state
+    let (final_state, start_time) = state
         .operations
         .read()
         .await
         .get(&operation_id)
-        .map(|s| match s.status {
-            OperationStatus::Successful => "SUCCESSFUL",
-            OperationStatus::Failed => "FAILED",
-            OperationStatus::Processing => "PROCESSING",
+        .map(|s| {
+            let state = match s.status {
+                OperationStatus::Successful => "SUCCESSFUL",
+                OperationStatus::Failed => "FAILED",
+                OperationStatus::Processing => "PROCESSING",
+            };
+            (state.to_string(), s.start_time.to_rfc3339())
         })
-        .unwrap_or("PROCESSING")
-        .to_string();
+        .unwrap_or_else(|| ("PROCESSING".to_string(), operation_start_time.to_rfc3339()));
 
     let response = ImportResponse {
         name: format!("projects/{}/operations/{}", project_id, operation_id),
@@ -184,7 +187,7 @@ pub async fn import_handler(state: AppState, project_id: String, body: Bytes) ->
             type_url: "type.googleapis.com/google.datastore.admin.v1.ImportEntitiesMetadata"
                 .to_string(),
             common: CommonMetadata {
-                start_time: Utc::now().to_rfc3339(),
+                start_time,
                 operation_type: "IMPORT_ENTITIES".to_string(),
                 state: final_state,
             },
@@ -590,6 +593,10 @@ mod tests {
         let operations = state.operations.read().await;
         assert_eq!(operations.len(), 1);
         let operation = operations.values().next().unwrap();
+        assert_eq!(
+            v["metadata"]["common"]["startTime"],
+            operation.start_time.to_rfc3339()
+        );
         assert!(matches!(operation.status.clone(), OperationStatus::Failed));
         assert!(operation
             .error

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -161,6 +161,7 @@ pub async fn import_handler(state: AppState, project_id: String, body: Bytes) ->
         state.operations.clone(),
         operation_id.clone(),
         payload.input_url.clone(),
+        Some(project_id.clone()),
     )
     .await;
 


### PR DESCRIPTION
## What changed

- Normalize Datastore import inputs before calling `import_dump`, supporting export roots, `exports/` directories, direct `.overall_export_metadata` files, and zip archives.
- Zip imports now extract into a unique temp directory per import instead of shared `dump/`, and that directory is cleaned up after import.
- GCS downloads now use unique temp file names and are cleaned up even when export preparation fails.
- Return the final import operation state from the REST import response after the import completes, using the recorded operation start time.
- Import REST requests pass the URL project ID through to import processing, so imported entity keys and key-valued properties are rewritten to the local project.
- Legacy App Engine app IDs such as `s~source-project` are normalized to the bare Datastore project ID during import conversion.
- The LevelDB log reader is block-aware, skips zero-filled block trailers, and rejects non-zero trailer bytes.
- Malformed/missing export metadata now fails the import instead of becoming a successful empty import.
- Export metadata and output paths are validated as safe relative paths before joining, and per-kind export metadata must include `items`.

## Why

The previous import path always extracted input into `./dump` and always imported from that directory, which failed for already-unpacked Datastore export directories or direct metadata-file paths. Imports also needed to handle exported project IDs that differ from the local emulator project, LevelDB block trailers, malformed dumps, and unsafe dump paths without silently succeeding.

## Tests

Added focused tests for:

- export path preparation from export root, `exports/`, and direct `.overall_export_metadata` inputs
- unique GCS temp path generation while preserving useful basename/suffix behavior
- zip extraction into unique temp directories
- REST import failed-state reporting and recorded start time reuse
- legacy app ID normalization for entity keys and key-valued properties
- project ID rewriting during import
- import failure when overall export metadata is missing
- import failure when per-kind metadata `items` are missing
- rejection of unsafe export metadata and output paths
- LevelDB record reading after a 32 KiB block trailer
- LevelDB rejection of non-zero block trailer bytes

## Validation

- `git diff --check`
- `docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app datastore-emulator-test-builder bash -c 'export PATH=/usr/local/cargo/bin:$PATH; rustup component add rustfmt >/dev/null && rustfmt --edition 2024 --check src/database.rs src/import.rs src/leveldb.rs'`
- `docker run --rm -v "$PWD":/usr/src/app -v datastore-emulator-target:/usr/src/app/target -w /usr/src/app datastore-emulator-test-builder cargo test --locked`